### PR TITLE
Converted all Python 2 scripts to Python 3

### DIFF
--- a/Ada/compile_all.py
+++ b/Ada/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/C++/compile_all.py
+++ b/C++/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/C/compile_all.py
+++ b/C/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/CSharp/compile_all.py
+++ b/CSharp/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Chapel/compile_all.py
+++ b/Chapel/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Dart/compile_all.py
+++ b/Dart/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Erlang/compile_all.py
+++ b/Erlang/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Fortran/compile_all.py
+++ b/Fortran/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Go/compile_all.py
+++ b/Go/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Hack/compile_all.py
+++ b/Hack/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Haskell/compile_all.py
+++ b/Haskell/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/JRuby/compile_all.py
+++ b/JRuby/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/JavaScript/compile_all.py
+++ b/JavaScript/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Julia/compile_all.py
+++ b/Julia/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Lisp/compile_all.py
+++ b/Lisp/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Lua/compile_all.py
+++ b/Lua/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/OCaml/compile_all.py
+++ b/OCaml/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/PHP/compile_all.py
+++ b/PHP/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Pascal/compile_all.py
+++ b/Pascal/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Perl/compile_all.py
+++ b/Perl/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Python/compile_all.py
+++ b/Python/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Racket/compile_all.py
+++ b/Racket/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking ' + root
+    print('Checking ' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
       if action == 'measure':
         call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Ruby/compile_all.py
+++ b/Ruby/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Rust/compile_all.py
+++ b/Rust/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Smalltalk/compile_all.py
+++ b/Smalltalk/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/Swift/compile_all.py
+++ b/Swift/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()

--- a/TypeScript/compile_all.py
+++ b/TypeScript/compile_all.py
@@ -12,7 +12,7 @@ def file_exists(file_path):
 
 def main():
   for root, dirs, files in os.walk(path):
-    print 'Checking' + root
+    print('Checking' + root)
     makefile = os.path.join(root, "Makefile")
     if file_exists(makefile):
       cmd = 'cd ' + root + '; make ' + action
@@ -24,15 +24,15 @@ def main():
         if pipes.returncode != 0:
           # an error happened!
           err_msg = "%s. Code: %s" % (std_err.strip(), pipes.returncode)
-          print '[E] Error on ' + root + ': '
-          print err_msg
+          print('[E] Error on ' + root + ': ')
+          print(err_msg)
         elif len(std_err):
           # return code is 0 (no error), but we may want to
           # do something with the info on std_err
           # i.e. logger.warning(std_err)
-          print '[OK]'
+          print('[OK]')
         else:
-          print '[OK]'
+          print('[OK]')
     if action == 'measure':
       call(['sleep', '5'])
 
@@ -40,13 +40,13 @@ if __name__ == '__main__':
   if len(sys.argv) == 2:
     act = sys.argv[1]
     if (act == 'compile') | (act == 'run') | (act == 'clean') | (act == 'measure'):
-      print 'Performing \"' + act + '\" action...'
+      print('Performing \"' + act + '\" action...')
       action = act
     else:
-      print 'Error: Unrecognized action \"' + act + '\"'
+      print('Error: Unrecognized action \"' + act + '\"')
       sys.exit(1)
   else:
-    print 'Performing \"compile\" action...'
+    print('Performing \"compile\" action...')
     action = 'compile'
   
   main()


### PR DESCRIPTION
I was unable to compile a few different languages with the `compile_all.py` scripts. I noticed that some were using the Python 2 style print statements so I converted them all to Python 3 with the `2to3` tool.

I ran:

```
find . -name "compile_all.py" -exec 2to3 -w {} \;
```

And then I discarded the following updated scripts that were already converted:
- `FSharp/compile_all.py`
- `Java/compile_all.py`
- `Java-GraalVM/compile_all.py`
- `compile_all.py`